### PR TITLE
Add diagnostic test for s2fft build mismatch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+This repository uses [Pixi](https://prefix.dev/pixi/) to manage dependencies.
+All commands (tests, formatting, etc.) should be run with `pixi run` to ensure
+that they use the correct environment. Run tests using `pixi run pytest`.

--- a/tests/test_s2fft_build.py
+++ b/tests/test_s2fft_build.py
@@ -1,0 +1,17 @@
+import pathlib
+import sys
+import pytest
+
+
+def test_s2fft_extension_matches_python():
+    try:
+        import s2fft_lib
+    except Exception as exc:
+        pytest.skip(f"s2fft_lib not available: {exc}")
+    libs = list(pathlib.Path(s2fft_lib.__path__[0]).glob("_s2fft*.so"))
+    assert libs, "_s2fft extension missing"
+    fname = libs[0].name
+    expected_tag = f"cpython-{sys.version_info.major}{sys.version_info.minor}"
+    assert expected_tag in fname, (
+        f"Extension built for different Python version: {fname}, expected {expected_tag}")
+

--- a/tests/test_s2fft_import.py
+++ b/tests/test_s2fft_import.py
@@ -1,0 +1,9 @@
+import importlib
+import pytest
+
+def test_can_import_s2fft():
+    try:
+        importlib.import_module("s2fft")
+    except Exception as exc:
+        pytest.fail(f"Could not import s2fft: {exc}")
+


### PR DESCRIPTION
## Summary
- add `tests/test_s2fft_build.py` to check the compiled extension matches the running Python version

## Testing
- `pixi run pytest -k s2fft -vv` *(fails: s2fft missing, debug test skipped)*

------
https://chatgpt.com/codex/tasks/task_e_683a311510b88324a73d20293ac8505f