### PR TITLE
Update Pixi usage in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,18 @@
 This repository uses [Pixi](https://prefix.dev/pixi/) to manage dependencies.
-All commands (tests, formatting, etc.) should be run with `pixi run` to ensure
-that they use the correct environment. Run tests using `pixi run pytest`.
+Always invoke commands through `pixi run` so they use the correct environment.
+
+The `dev` environment contains the `s2fft` git dependency used in the tests.
+Run tests with:
+
+```
+pixi run --environment dev pytest
+```
+
+or simply `pixi run test`. Add `--frozen` to reuse the existing environment
+without reinstalling packages each time.
+
+You can also start a shell in the `dev` environment and execute commands there:
+
+```
+pixi shell --environment dev
+```


### PR DESCRIPTION
## Summary
- update AGENTS.md with clearer pixi instructions

## Testing
- `pixi run --frozen --environment dev pytest` *(fails: error parsing locked git url)*

------
https://chatgpt.com/codex/tasks/task_e_683b56cc9aec83249247b80cc4b377a8